### PR TITLE
Add csv-parser and papaparse to benchmark

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var csvtojson = require('csvtojson')
 var csv = require('csv')
 var fastCsv = require('fast-csv')
+var csvParser = require('csv-parser')
 var csvFile = '1.csv'
 var outputFile = "output.txt";
 console.time("fast-csv")
@@ -14,6 +15,10 @@ testFastCsv(function () {
     console.time("csvtojson")
     testCsvToJson(function () {
       console.timeEnd("csvtojson")
+      console.time("csv-parser")
+      testCsvParser(function () {
+        console.timeEnd("csv-parser")
+      })
     })
   })
 })
@@ -51,6 +56,20 @@ function testCsv(cb) {
   var ws = require('fs').createWriteStream(fileName)
   var rs = require('fs').createReadStream(csvFile)
   var stream=csv.parse();
+  rs.pipe(stream)
+  .on("data",function(d){
+    ws.write(d[0] + "\n")
+  })
+  .on("end",function(){
+    cb();
+  })
+}
+
+function testCsvParser(cb) {
+  var fileName = "csvParser-" + outputFile;
+  var ws = require('fs').createWriteStream(fileName)
+  var rs = require('fs').createReadStream(csvFile)
+  var stream = csvParser();
   rs.pipe(stream)
   .on("data",function(d){
     ws.write(d[0] + "\n")

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ var csvtojson = require('csvtojson')
 var csv = require('csv')
 var fastCsv = require('fast-csv')
 var csvParser = require('csv-parser')
+var Papa = require('papaparse')
+
 var csvFile = '1.csv'
 var outputFile = "output.txt";
 console.time("fast-csv")
@@ -18,6 +20,10 @@ testFastCsv(function () {
       console.time("csv-parser")
       testCsvParser(function () {
         console.timeEnd("csv-parser")
+        console.time("papaparse")
+        testPapaParse(function () {
+          console.timeEnd("papaparse")
+        })
       })
     })
   })
@@ -70,6 +76,20 @@ function testCsvParser(cb) {
   var ws = require('fs').createWriteStream(fileName)
   var rs = require('fs').createReadStream(csvFile)
   var stream = csvParser();
+  rs.pipe(stream)
+  .on("data",function(d){
+    ws.write(d[0] + "\n")
+  })
+  .on("end",function(){
+    cb();
+  })
+}
+
+function testPapaParse(cb) {
+  var fileName = "papaParse-" + outputFile;
+  var ws = require('fs').createWriteStream(fileName)
+  var rs = require('fs').createReadStream(csvFile)
+  var stream = Papa.parse(Papa.NODE_STREAM_INPUT)
   rs.pipe(stream)
   .on("data",function(d){
     ws.write(d[0] + "\n")

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "csvtojson": "^1.1.0",
     "csv": "^1.1.0",
+    "csv-parser": "^2.3.1",
+    "csvtojson": "^1.1.0",
     "fast-csv": "^2.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "csv": "^1.1.0",
     "csv-parser": "^2.3.1",
     "csvtojson": "^1.1.0",
-    "fast-csv": "^2.3.0"
+    "fast-csv": "^2.3.0",
+    "papaparse": "^5.1.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -26,10 +26,10 @@ Here is some result running on a 2019 Macbook Pro:
 
 ```
 $ node ./index.js
-fast-csv: 1594.408ms
 csv: 1890.357ms
-csvtojson: 437.571ms
+fast-csv: 1594.408ms
 csv-parser: 726.146ms
+csvtojson: 437.571ms
 $ node --version
 v12.4.0
 ```

--- a/readme.md
+++ b/readme.md
@@ -26,10 +26,11 @@ Here is some result running on a 2019 Macbook Pro:
 
 ```
 $ node ./index.js
-csv: 1890.357ms
-fast-csv: 1594.408ms
-csv-parser: 726.146ms
-csvtojson: 437.571ms
+csv: 1844.045ms
+fast-csv: 1681.046ms
+csv-parser: 722.762ms
+csvtojson: 436.225ms
+papaparse: 434.335ms
 $ node --version
 v12.4.0
 ```

--- a/readme.md
+++ b/readme.md
@@ -22,14 +22,15 @@ All parsers will simply do following
 
 # Result
 
-Here is some result running on a 2013 Macbook Pro: 
+Here is some result running on a 2019 Macbook Pro: 
 
 ```
 $ node ./index.js
-fast-csv: 5248.767ms
-csv: 3798.266ms
-csvtojson: 948.493ms
+fast-csv: 1594.408ms
+csv: 1890.357ms
+csvtojson: 437.571ms
+csv-parser: 726.146ms
 $ node --version
-v6.9.1
+v12.4.0
 ```
 


### PR DESCRIPTION
I also updated the benchmark in the readme after running it on my machine, to include the results of `csv-parser` and `papaparse` packages.