### PR TITLE
Add lil-csv, update readme with latest benchmarks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
-// var csv=require('fast-csv')
-// var csv=require('csv')
 var csvtojson = require('csvtojson')
 var csv = require('csv')
 var fastCsv = require('fast-csv')
 var csvParser = require('csv-parser')
 var Papa = require('papaparse')
+var lilCsv = require('lil-csv')
 
 var csvFile = '1.csv'
 var outputFile = "output.txt";
@@ -23,6 +22,10 @@ testFastCsv(function () {
         console.time("papaparse")
         testPapaParse(function () {
           console.timeEnd("papaparse")
+          console.time("lil-csv")
+          testLilCsv(function () {
+            console.timeEnd("lil-csv")
+          })
         })
       })
     })
@@ -97,4 +100,12 @@ function testPapaParse(cb) {
   .on("end",function(){
     cb();
   })
+}
+
+function testLilCsv(cb) {
+  var fileName = 'lilCsv-' + outputFile;
+  var fileContents = require('fs').readFileSync(csvFile, "utf-8")
+  var data = lilCsv.parse(fileContents, { header: false })
+  require('fs').writeFileSync(fileName, JSON.stringify(data.reduce((acc, row) => acc + "\n" + row[0], "")))
+  cb()
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "csv-parser": "^2.3.1",
     "csvtojson": "^1.1.0",
     "fast-csv": "^2.3.0",
+    "lil-csv": "^1.4.1",
     "papaparse": "^5.1.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -12,11 +12,15 @@ $ node ./index.js
 
 ## Procedure
 
-All parsers will simply do following
+All parsers (except `lil-csv`) will simply do following
 
 1. stream in 1.csv and start to parse
 2. get content from 1st column of each row and write to a file
 
+The `lil-csv` would
+
+1. read the whole 1.csv without streaming
+2. get content from 1st column of each row and write to a file
 
 `1.csv` contains 300K lines
 
@@ -26,11 +30,12 @@ Here is some result running on a 2019 Macbook Pro:
 
 ```
 $ node ./index.js
-csv: 1844.045ms
-fast-csv: 1681.046ms
-csv-parser: 722.762ms
-csvtojson: 436.225ms
-papaparse: 434.335ms
+fast-csv: 1438.705ms
+csv: 2346.760ms
+csvtojson: 435.524ms
+csv-parser: 878.652ms
+papaparse: 430.366ms
+lil-csv: 1135.411ms
 $ node --version
 v12.4.0
 ```


### PR DESCRIPTION
With this PR I'd like to make a point that streaming is not necessary to parse a large CSV fast enough.
Also, I've updated the README with new results from the `node index.js` execution. I also have 2019 Macbook Pro.

If this PR is something too much - I'd be happy to rework the way you see it.